### PR TITLE
0.8.0 Release

### DIFF
--- a/atomic_operator/__init__.py
+++ b/atomic_operator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 
 from .atomic_operator import AtomicOperator

--- a/atomic_operator/atomic_operator.py
+++ b/atomic_operator/atomic_operator.py
@@ -5,7 +5,8 @@ from .models import (
     Config
 )
 from .configparser import ConfigParser
-from .utils.exceptions import AtomicsFolderNotFound
+    IncorrectParameters
+)
 from .execution import (
     LocalRunner,
     RemoteRunner,
@@ -193,6 +194,15 @@ class AtomicOperator(Base):
         if debug:
             import logging
             logging.getLogger().setLevel(logging.DEBUG)
+        count = 0
+        if check_prereqs:
+            count += 1
+        if get_prereqs:
+            count += 1
+        if cleanup:
+            count += 1
+        if count > 1:
+            return IncorrectParameters(f"You have passed in incompatible arguments. Please only provide one of 'check_prereqs','get_prereqs','cleanup'.")
         atomics_path = self.__find_path(atomics_path)
         if not atomics_path:
             return AtomicsFolderNotFound('Unable to find a folder containing Atomics. Please provide a path or run get_atomics.')

--- a/atomic_operator/execution/copier.py
+++ b/atomic_operator/execution/copier.py
@@ -44,6 +44,12 @@ class Copier(Base):
             self.__logger.warning(f'Unable to execute copy of supporting file {file[-1]}')
             self.__logger.warning(f'STDIN: {ssh_stdin}/nSTDOUT: {ssh_stdout}/nSTDERR: {ssh_stderr}')
 
+    def copy_file(self, source, destination):
+        if self.ssh_client:
+            self.__copy_file_to_nix(source=source, destination=destination)
+        elif self.windows_client:
+            self.__copy_file_to_windows(source=source, destination=destination)
+
     def copy_directory_of_files(self, source, destination):
         return_list = []
         for dirpath, dirnames, files in os.walk(source):
@@ -75,6 +81,7 @@ class Copier(Base):
                             file_list = self.copy_directory_of_files(argument.source, argument.destination)
                             argument.value = argument.destination
                         else:
+                            self.copy_file(argument.source, argument.destination)
                             argument.value = self._replace_command_string(
                                 argument.default, 
                                 path='/tmp',

--- a/atomic_operator/execution/remoterunner.py
+++ b/atomic_operator/execution/remoterunner.py
@@ -26,7 +26,7 @@ class RemoteRunner(Runner):
         self.test = atomic_test
         self.test_path = test_path
 
-    def execute_process(self, command, executor=None, host=None, cwd=None):
+    def execute_process(self, command, executor=None, host=None, cwd=None, elevation_required=False):
         """Main method to execute commands using state machine
 
         Args:
@@ -44,7 +44,7 @@ class RemoteRunner(Runner):
                     self.state = self.state.on_event(executor, command)
                 if str(self.state) == 'InnvocationState':
                     self.__logger.debug('Running InnvocationState on_event')
-                    self.state = self.state.invoke(host, executor, command, input_arguments=self.test.input_arguments)
+                    self.state = self.state.invoke(host, executor, command, input_arguments=self.test.input_arguments, elevation_required=elevation_required)
                 if str(self.state) == 'ParseResultsState':
                     self.__logger.debug('Running ParseResultsState on_event')
                     final_state = self.state.on_event()

--- a/atomic_operator/execution/runner.py
+++ b/atomic_operator/execution/runner.py
@@ -91,9 +91,7 @@ class Runner(Base):
                 command=self.test.executor.command,
                 executor=executor,
                 host=host,
-                cwd=self.test_path
-            )
-            return_dict.update({'command': response})
+                    elevation_requred=self.test.executor.elevation_required
             if Runner.CONFIG.cleanup and self.test.executor.cleanup_command:
                 self.__logger.debug("Running cleanup command")
                 cleanup_response = self.execute_process(
@@ -110,5 +108,5 @@ class Runner(Base):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def execute_process(self, command, executor=None, host=None, cwd=None):
+    def execute_process(self, command, executor=None, host=None, cwd=None, elevation_requred=False):
         raise NotImplementedError


### PR DESCRIPTION
# Please know that major changes occurred in this release. 

To be in sync with the Invoke-Atomic project, I have modified how the parameters work for the `run` command. 

You can now only provide one of the following parameters (all others stay the same). 
* check_prereqs #39 
* get_prereqs #40
* cleanup

We will now run these defined commands (just like Invoke-Atomic does currently) and will not run the `run` command.

If none of these are specified then we will run the executor.command.

## Other changes
* Added elevation_required parameter for remote connections #37 
* Updated the copying of source files #38 
* Added better error handling when parameters are typed in with typos. #41