### PR TITLE
Host Platform arg and Fix for input.default not being iterable. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ You can install **atomic-operator** on OS X, Linux, or Windows. You can also ins
 The following libraries are required and installed by atomic-operator:
 
 ```
-pyyaml==5.4.1
-fire==0.4.0
-requests==2.26.0
-attrs==21.2.0
-pick==1.2.0
+atomic-operator-runner==^0.2.1
+rich==^13.3.1
+fire==^0.5.0
+attrs==^23.1.0
+pick==^2.2.0
 ```
 
 ### macOS, Linux and Windows:
@@ -86,29 +86,12 @@ pick==1.2.0
 pip install atomic-operator
 ```
 
-### macOS using M1 processor
-
-```bash
-git clone https://github.com/swimlane/atomic-operator.git
-cd atomic-operator
-
-# Satisfy ModuleNotFoundError: No module named 'setuptools_rust'
-brew install rust
-pip3 install --upgrade pip
-pip3 install setuptools_rust
-
-# Back to our regularly scheduled programming . . .  
-pip install -r requirements.txt
-python setup.py install
-```
-
 ### Installing from source
 
 ```bash
 git clone https://github.com/swimlane/atomic-operator.git
 cd atomic-operator
-pip install -r requirements.txt
-python setup.py install
+pip install .
 ```
 
 ## Usage example (command line)
@@ -173,8 +156,8 @@ atomic-operator run --techniques T1564.001 --input_arguments '{"project-id": "so
 In order to run a test remotely you must provide some additional properties (and options if desired). The main method to run tests is named `run`.
 
 ```bash
-# This will run ALL tests compatiable with your local operating system
-atomic-operator run --atomics-path "/tmp/some_directory/redcanaryco-atomic-red-team-3700624" --hosts "10.32.1.0" --username "my_username" --password "my_password"
+# This will run ALL tests compatiable with your specified operating system
+atomic-operator run --atomics-path "/tmp/some_directory/redcanaryco-atomic-red-team-3700624" --hosts "{'10.32.1.0':'linux'}" --username "my_username" --password "my_password"
 ```
 
 > When running commands remotely against Windows hosts you may need to configure PSRemoting. See details here: [Windows Remoting](docs/windows-remote.md)
@@ -206,7 +189,7 @@ atomic-operator run -- --help
 |return_atomics|bool|False|Whether or not you want to return atomics instead of running them.|
 |config_file|str|None|A path to a conifg_file which is used to automate atomic-operator in environments.|
 |config_file_only|bool|False|Whether or not you want to run tests based on the provided config_file only.|
-|hosts|list|None|A list of one or more remote hosts to run a test on.|
+|hosts|dict|None|A list of one or more remote hosts to run a test on.|
 |username|str|None|Username for authentication of remote connections.|
 |password|str|None|Password for authentication of remote connections.|
 |ssh_key_path|str|None|Path to a SSH Key for authentication of remote connections.|
@@ -280,8 +263,8 @@ FLAGS
         Default: False
         Whether or not you want to run tests based on the provided config_file only. Defaults to False.
     --hosts=HOSTS
-        Default: []
-        A list of one or more remote hosts to run a test on. Defaults to [].
+        Default: {}
+        A dictionary of one or more remote hosts and their respective platform to run a test on. Defaults to [].
     --username=USERNAME
         Type: Optional[]
         Default: None

--- a/atomic_operator/atomic_operator.py
+++ b/atomic_operator/atomic_operator.py
@@ -110,8 +110,6 @@ class AtomicOperator(Base):
             config_args = self.__config_parser.get_inputs(test.auto_generated_guid)
             if config_args:
                 self._set_input_arguments(test, **config_args)
-            if test.auto_generated_guid not in self.__test_responses:
-                self.__test_responses[test.auto_generated_guid] = {}
             if technique.hosts:
                 for host in technique.hosts:
                     if host.platform in self.SUPPORTED_PLATFORMS:

--- a/atomic_operator/atomic_operator.py
+++ b/atomic_operator/atomic_operator.py
@@ -114,55 +114,56 @@ class AtomicOperator(Base):
                 self.__test_responses[test.auto_generated_guid] = {}
             if technique.hosts:
                 for host in technique.hosts:
-                    if host.platform in test.supported_platforms and host.platform in self.SUPPORTED_PLATFORMS:
-                        if test.auto_generated_guid not in self.__test_responses:
-                            self.__test_responses[test.auto_generated_guid] = {}
-                        self.__logger.info(
-                            f"Running {test.name} test ({test.auto_generated_guid}) for technique {technique.attack_technique}"
-                        )
-                        self.__logger.debug(f"Description: {test.description}")
-                        self.__logger.debug(f"Running test on {host.platform} platform.")
-                        # TODO: Need to add support for copy of files to remote hosts.
-                        path = technique.path
-                        if host.platform == "windows":
-                            path = "c:\\temp"
-                        elif host.platform == "linux" or host.platform == "macos" or host.platform == "aws":
-                            path = "/tmp"
-                        else:
-                            raise PlatformNotSupportedError(
-                                provided_platform=host.platform, supported_platforms=self.SUPPORTED_PLATFORMS
-                            )
-                        self.__logger.debug(f"The original execution command is '{test.executor.command}'.")
-                        new_command = self._replace_command_string(
-                            command=test.executor.command,
-                            path=path,
-                            input_arguments=test.input_arguments,
-                            executor=test.executor.name,
-                        )
-                        self.__logger.debug(f"Newly formatted execution command is '{new_command}'.")
-                        runner = Runner(
-                            platform=host.platform,
-                            hostname=host.hostname,
-                            username=host.username,
-                            password=host.password,
-                            verify_ssl=host.verify_ssl,
-                            ssh_key_path=host.ssh_key_path,
-                            private_key_string=host.private_key_string,
-                            ssh_port=host.port,
-                            ssh_timeout=host.timeout,
-                        )
-                        for response in runner.run(
-                            command=new_command,
-                            executor=test.executor.name,
-                            elevation_required=test.executor.elevation_required,
-                        ):
-                            self.__test_responses[test.auto_generated_guid].update(
-                                {
-                                    "technique_id": technique.attack_technique,
-                                    "technique_name": technique.display_name,
-                                    "response": response,
-                                }
-                            )
+                    if host.platform in self.SUPPORTED_PLATFORMS:
+                        if host.platform in test.supported_platforms:
+                            if test.auto_generated_guid not in self.__test_responses:
+                                self.__test_responses[test.auto_generated_guid] = {}
+                                self.__logger.info(
+                                    f"Running {test.name} test ({test.auto_generated_guid}) for technique {technique.attack_technique}"
+                                )
+                                self.__logger.debug(f"Description: {test.description}")
+                                self.__logger.debug(f"Running test on {host.platform} platform.")
+                                # TODO: Need to add support for copy of files to remote hosts.
+                                path = technique.path
+                                if host.platform == "windows":
+                                    path = "c:\\temp"
+                                elif host.platform == "linux" or host.platform == "macos" or host.platform == "aws":
+                                    path = "/tmp"
+                                else:
+                                    raise PlatformNotSupportedError(
+                                        provided_platform=host.platform, supported_platforms=self.SUPPORTED_PLATFORMS
+                                    )
+                                self.__logger.debug(f"The original execution command is '{test.executor.command}'.")
+                                new_command = self._replace_command_string(
+                                    command=test.executor.command,
+                                    path=path,
+                                    input_arguments=test.input_arguments,
+                                    executor=test.executor.name,
+                                )
+                                self.__logger.debug(f"Newly formatted execution command is '{new_command}'.")
+                                runner = Runner(
+                                    platform=host.platform,
+                                    hostname=host.hostname,
+                                    username=host.username,
+                                    password=host.password,
+                                    verify_ssl=host.verify_ssl,
+                                    ssh_key_path=host.ssh_key_path,
+                                    private_key_string=host.private_key_string,
+                                    ssh_port=host.port,
+                                    ssh_timeout=host.timeout,
+                                )
+                                for response in runner.run(
+                                    command=new_command,
+                                    executor=test.executor.name,
+                                    elevation_required=test.executor.elevation_required,
+                                ):
+                                    self.__test_responses[test.auto_generated_guid].update(
+                                        {
+                                            "technique_id": technique.attack_technique,
+                                            "technique_name": technique.display_name,
+                                            "response": response,
+                                        }
+                                    )
                     else:
                         raise PlatformNotSupportedError(
                             provided_platform=host.platform, supported_platforms=self.SUPPORTED_PLATFORMS

--- a/atomic_operator/base.py
+++ b/atomic_operator/base.py
@@ -155,8 +155,9 @@ Inputs for {title}:
                 if test.executor.name == key:
                     for k, v in val.items():
                         for input in test.input_arguments:
-                            if k in input.default:
-                                input.value = input.default.replace(k, v)
+                            if input.type == 'path':
+                                if k in input.default:
+                                    input.value = input.default.replace(k, v)
             for input in test.input_arguments:
                 if input.value == None:
                     input.value = input.default

--- a/atomic_operator/base.py
+++ b/atomic_operator/base.py
@@ -194,4 +194,4 @@ Inputs for {title}:
         try:
             getattr(getattr(parent, f"_{component}__logger"), level)(message)
         except AttributeError as ae:
-            getattr(self.__logger, level)(message + ae)
+            getattr(self.__logger, level)(message + str(ae))

--- a/atomic_operator/configparser.py
+++ b/atomic_operator/configparser.py
@@ -85,7 +85,7 @@ class ConfigParser(Base):
                 self.__host_list.append(
                     self.__create_remote_host_object(
                         hostname=host,
-                        platform=host_dict(host),
+                        platform=host_dict[host],
                         username=username,
                         password=password,
                         ssh_key_path=ssh_key_path,

--- a/atomic_operator/configparser.py
+++ b/atomic_operator/configparser.py
@@ -12,7 +12,7 @@ class ConfigParser(Base):
         config_file=None,
         techniques=None,
         test_guids=None,
-        host_list=None,
+        host_dict=None,
         username=None,
         password=None,
         ssh_key_path=None,
@@ -80,11 +80,12 @@ class ConfigParser(Base):
         self.test_guids = test_guids
         self.select_tests = select_tests
         self.__host_list = []
-        if host_list:
-            for host in self.parse_input_lists(host_list):
+        if host_dict:
+            for host in host_dict:
                 self.__host_list.append(
                     self.__create_remote_host_object(
                         hostname=host,
+                        platform=host_dict(host),
                         username=username,
                         password=password,
                         ssh_key_path=ssh_key_path,

--- a/atomic_operator/configparser.py
+++ b/atomic_operator/configparser.py
@@ -129,6 +129,7 @@ class ConfigParser(Base):
     def __create_remote_host_object(
         self,
         hostname=None,
+        platform=None,
         username=None,
         password=None,
         ssh_key_path=None,
@@ -139,6 +140,7 @@ class ConfigParser(Base):
     ):
         return Host(
             hostname=hostname,
+            platform=platform,
             username=username,
             password=password,
             ssh_key_path=ssh_key_path,

--- a/atomic_operator/models.py
+++ b/atomic_operator/models.py
@@ -42,6 +42,7 @@ class Config:
 @attr.s
 class Host:
     hostname = attr.ib(type=str)
+    platform = attr.ib(type=str)
     username = attr.ib(default=None, type=str)
     password = attr.ib(default=None, type=str)
     verify_ssl = attr.ib(default=False, type=bool)


### PR DESCRIPTION
I modified the `--host` argument to accept a dictionary so now it'll look like `--host '{"hostname":"platform"}'`. 
Before, without selecting a platform, tests would possibly run multiple times due to running for how many supported platoforms there were in the test files. 

For example, [T1098.004](https://github.com/redcanaryco/atomic-red-team/blob/f1dfe9b8efc3d67c6d9a1017f52fbea5e03e34e1/atomics/T1098.004/T1098.004.yaml) supported linux and macos, so it would run twice for each host provided. For this exact test, it isn't an issue, but could possibly be for other tests. 

I also modified the code to check for the provided platform and only spit out test informaton if the platform was supported. Before, the cli would output all the GUIDs as empty dicts even for tests it wouldn't/couldn't run. This was mostly to clean up output. 

I also added code to check a tests input argument type. There was an issue where it would try to replace the temp env variable if the executator was powershell. Some input args were ints and this would cause an error. So now, if the input.type isn't a path, then it won't try to do that. This kind of relates to #78 .

Finally, I updated some of the install instructions on the Readme to reflect current options for installing. 